### PR TITLE
Fix: sometimes contents() returns mixed arrays and Item objects.

### DIFF
--- a/src/Moltin/Cart/Storage/LaravelSession.php
+++ b/src/Moltin/Cart/Storage/LaravelSession.php
@@ -59,10 +59,10 @@ class LaravelSession implements \Moltin\Cart\StorageInterface
 
         if ( ! $asArray) return $cart;
 
-        $data = $cart;
+        $data = [];
 
-        foreach ($data as &$item) {
-            $item = $item->toArray();
+        foreach ($cart as &$item) {
+            $data[] = $item->toArray();
         }
 
         return $data;


### PR DESCRIPTION
One of two exceptions appeared, depending on object/array order in result of `contents()` call:
1. `Trying to get property of non-object`
2. `Call to a member function toArray() on array`

This happens when `contents()` is called more than once.
